### PR TITLE
Version 2.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ import sys
 import urllib
 
 from py9kw import Py9kw
-# This example is similar to the one inside py9kw.py __main__
 
-captchaSolver = Py9kw('<your_apikey>', False, True)
-captchaSolver.setPriority(1)
+captchaSolver = Py9kw('<APIKEY>', False, True)
 captchaSolver.setTimeout(62)
+# Define exactly what we expect as a result according to: https://www.9kw.eu/api.html#apisubmit-tab
+captchaSolver.setAdditionalCaptchaUploadParams({'numeric': '1', 'min_len': '7', 'max_len': '7'})
 
-creds, erri, errm = captchaSolver.getcredits()
+creds, errorint, errormsg = captchaSolver.getcredits()
 print('Credits left: %d' % creds)
 
 test_url = 'https://confluence.atlassian.com/download/attachments/216957808/captcha.png?version=1&modificationDate=1272411042125&api=v2'
@@ -48,10 +48,10 @@ Most of all possible errorcodes with their corresponding errormessages are liste
 
 Errorcode | Explanation
 --- | ---
-600 | ERROR_NO_USER This happens when there are no users to solve and the timeout of the uploaded captcha ran out. Example API json: {"status":{"https":1,"success":true},"message":"OK","answer":"ERROR NO USER"}
-601 | CAPTCHA_DOWNLOAD_FAILURE This may happen before a captcha gets sent to 9kw if the provided URL is e.g. offline or returns an http error status.
-602 | ERROR_TIMEOUT Basically the same as 600 but in this case, the internal timout happened before the Server timeout happened.
-603 | NO_ANSWER_YET No captcha result available yet. This is the only case in which sleepAndGetResult is allowed to retry. Example API json: {"answer":"NO DATA","message":"OK","nodata":1,"status":{"success":true,"https":1},"info":1}
+600 | ERROR_NO_USER This happens when there were no users available to solve the uploaded captcha within the given maxtimeout. Example API json: {"status":{"https":1,"success":true},"message":"OK","answer":"ERROR NO USER"}
+601 | ERROR_TIMEOUT Basically the same as 600 but in this case, the internal timout happened before the serverside timeout happened.
+602 | NO_ANSWER_YET No captcha result available yet. This is the only case in which sleepAndGetResult is allowed to retry. Example API json: {"answer":"NO DATA","message":"OK","nodata":1,"status":{"success":true,"https":1},"info":1}
+603 | CAPTCHA_DOWNLOAD_FAILURE This may happen before a captcha gets sent to 9kw if the provided URL is e.g. offline or returns an http error status.
 666 | Error while parsing error number and message --> This should never happen
 0012 | **Special case returned by API: 0012 Bereits erledigt.** This will return an errorcode along with a (correct)captcha result!
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from distutils.core import setup
 
 setup(name='python3-py9kw',
-      version='2.1.1',
+      version='2.1.2',
       description='Captcha Solving Service library for 9kw.eu API',
       author1='Jan Helbling',
       author1_email='jan.helbling@mailbox.org',


### PR DESCRIPTION
- Re-arranged some internal errorcodes
- Send no prio at all by default --> this lib finally only uses the default 10 credits per captcha - it was 11 credits in all versions before lol
- Added setAdditionalCaptchaUploadParams so the other captcha params are easily usable, see API docs and updated example in readme
- Updated readme.md